### PR TITLE
scrape-it 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Have an idea? Found a bug? See [how to contribute][contributing].
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
 
+ - [`codementor`](https://github.com/IonicaBizau/codementor#readme)—A scraper for codementor.io.
  - [`ui-studentsearch`](https://github.com/rkkautsar/ui-studentsearch#readme) (by Rakha Kanz Kautsar)—API for majapahit.cs.ui.ac.id/studentsearch
 
 ## :scroll: License

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "humans"
   ],
   "license": "MIT",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "lib/index.js",
   "scripts": {
     "test": "node test"
@@ -41,5 +41,17 @@
   "devDependencies": {
     "lien": "^1.0.1",
     "tester": "^1.3.2"
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "scripts/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.