### PR TITLE
Fix TS types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,7 +29,7 @@ declare namespace scrapeIt {
     export function scrapeHTML<T>(body: CheerioStatic | string, options: ScrapeOptions): T;
 }
 
-declare function scrapeIt<T>(url: string | object, opts: scrapeIt.ScrapeOptions): Promise<ScrapeResult<T>>;
+declare function scrapeIt<T>(url: string | object, opts: scrapeIt.ScrapeOptions): Promise<scrapeIt.ScrapeResult<T>>;
 
-declare function scrapeIt<T>(url: string | object, opts: scrapeIt.ScrapeOptions, cb: (err: any, res: ScrapeResult<T>) => void): void;
+declare function scrapeIt<T>(url: string | object, opts: scrapeIt.ScrapeOptions, cb: (err: any, res: scrapeIt.ScrapeResult<T>) => void): void;
 export = scrapeIt;


### PR DESCRIPTION
Should fix the following errors:

```
node_modules/scrape-it/lib/index.d.ts(32,91): error TS2304: Cannot find name 'ScrapeResult'.
node_modules/scrape-it/lib/index.d.ts(34,102): error TS2304: Cannot find name 'ScrapeResult'.
```

I suggest a minor version bump ASAP, as this is breaking TS builds.