### PR TITLE
Allow for converting list items with shorthand

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,9 +14,14 @@ declare namespace scrapeIt {
         texteq?: number;
     }
 
-    export interface ScrapeOptionList {
+    export interface ScrapeOptionListWithData {
         listItem: string;
         data: ScrapeOptions;
+    }
+
+    export interface ScrapeOptionListWithConvert {
+        listItem: string;
+        convert?: (value: any) => any;
     }
 
     export interface ScrapeResult<T> {

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,8 +169,9 @@ scrapeIt.scrapeHTML = ($, opts) => {
                     }
 
                     for (let i = 0; i < $items.length; ++i) {
-                        let cDoc = handleDataObj(cOpt.data, $items.eq(i))
-                        docs.push(cDoc.___raw || cDoc)
+												let cDoc = handleDataObj(cOpt.data, $items.eq(i))
+												let convert = cOpt.convert || function(x) { return x }
+                        docs.push(convert(cDoc.___raw || cDoc))
                     }
                 } else {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,8 +169,8 @@ scrapeIt.scrapeHTML = ($, opts) => {
                     }
 
                     for (let i = 0; i < $items.length; ++i) {
-												let cDoc = handleDataObj(cOpt.data, $items.eq(i))
-												let convert = cOpt.convert || function(x) { return x }
+                        let cDoc = handleDataObj(cOpt.data, $items.eq(i))
+                        let convert = cOpt.convert || function(x) { return x }
                         docs.push(convert(cDoc.___raw || cDoc))
                     }
                 } else {

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,20 @@ tester.describe("scrape-it", t => {
             cb();
         });
     });
+    t.it("scrape and convert lists", cb => {
+        scrapeIt(URL, {
+            features: {
+                listItem: ".features > li",
+                convert: x => parseInt(x, 10)
+            }
+        }, (err, { data }) => {
+            t.expect(err).toBe(null);
+            t.expect(data).toEqual({
+                features: [1, 2, 3, 4, 5, 6]
+            });
+            cb();
+        });
+    });
     t.it("promise version", cb => {
         scrapeIt(URL, {
             features: {


### PR DESCRIPTION
The following was previously not supported, but should be with this PR:

Given the following HTML
```html
<span class="birthday">1990-01-01</span>
<span class="birthday">1990-04-06</span>
<span class="birthday">1965-03-23</span>
<span class="birthday">1931-01-21</span>
```

You can retrieve the items using the `listItem` mechanism, this was already possible. However, there was no way to convert the listItems directly, so the following doesn't work in the currently published version:
```js
scrapeIt(url, {
  birthdays: {
    listItem: '.birthday',
    convert: x => new Date(x)
}).then(...)
```