### PR TITLE
fix: TypeScript definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 declare namespace scrapeIt {
     export interface ScrapeOptions {
-        [key: string]: string | ScrapeOptionList | ScrapeOptionElement;
+        [key: string]: string | ScrapeOptionListWithData | ScrapeOptionListWithConvert | ScrapeOptionElement;
     }
 
     export interface ScrapeOptionElement {


### PR DESCRIPTION
This tiny PR fixes the TypeScript definitions, allowing TS users to use this module.