### PR TITLE
Include latest @types/cheerio

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ declare namespace scrapeIt {
     export interface ScrapeOptionElement {
         selector?: string;
         convert?: (value: any) => any;
-        how?: string | ((element: CheerioSelector) => any);
+        how?: string | ((element: cheerio.Selector) => any);
         attr?: string;
         trim?: boolean;
         closest?: string;
@@ -24,12 +24,12 @@ declare namespace scrapeIt {
 
     export interface ScrapeResult<T> {
         data: T,
-        $: Cheerio,
+        $: cheerio.Cheerio,
         response: any,
         body: string
     }
 
-    export function scrapeHTML<T>(body: CheerioStatic | string, options: ScrapeOptions): T;
+    export function scrapeHTML<T>(body: cheerio.Root | string, options: ScrapeOptions): T;
 }
 
 declare function scrapeIt<T>(url: string | object, opts: scrapeIt.ScrapeOptions): Promise<scrapeIt.ScrapeResult<T>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/cheerio": {
+      "version": "0.22.29",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.29.tgz",
+      "integrity": "sha512-rNX1PsrDPxiNiyLnRKiW2NXHJFHqx0Fl3J2WsZq0MTBspa/FgwlqhXJE2crIcc+/2IglLHtSWw7g053oUR8fOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     ]
   },
   "dependencies": {
+    "@types/cheerio": "^0.22.29",
     "assured": "^1.0.14",
     "cheerio-req": "^1.2.3",
     "scrape-it-core": "^1.0.0",


### PR DESCRIPTION
Closes #157.

Hi, thanks for the awesome product!

As pointed out in the issue #157, some type errors occur when you use scrape-it with TypeScript. That's because this product does not include `@types/cheerio` in dependencies. Moreover, old definitions in `@types/cheerio` are used in `lib/index.d.ts` so that installing the latest `@types/cheerio` does not help.

To reproduce the errors, you just need to:
* Run `npm ci` and do nothing else
* Write a very simple TypeScript program in which `./lib` is imported.
* Run tsc and you will see the errors

Here I made some changes:
* Install the latest `@types/cheerio`
* Fix `lib/index.d.ts`

I confirmed that these changes successfully pass a simple build task without errors.

There will be other ways to fix the issue, such as making some changes to use the latest cheerio (officially typed!) instead of installing `@types/cheerio`. That will be fine, but I think my proposal is the easiest way to fix the problem.