### PR TITLE
docs: remove out-of-date description

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "blah": {
     "h_img": "https://i.imgur.com/j3Z0rbN.png",
     "cli": "scrape-it-cli",
-    "description": "Want to save time or not using Node.js? Try our [hosted API](https://scrape-it.saasify.sh).",
+    "description": "",
     "installation": [
       {
         "h2": "FAQ"


### PR DESCRIPTION
From saasify.sh: _"As of January 2022, the Saasify platform has been shut down."_
The service being not available anymore, it should not be referenced.