### PR TITLE
Update DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,7 +38,7 @@ For the format of the selector, please refer to the [Selectors section of the Ch
            value.
          - `attr` (String): If provided, the value will be taken based on
            the attribute name.
-         - `trim` (Boolean): If `false`, the value will *not* be trimmed
+         - `trimValue` (Boolean): If `false`, the value will *not* be trimmed
            (default: `true`).
          - `closest` (String): If provided, returns the first ancestor of
            the given element.


### PR DESCRIPTION
update the field `trimValue`, the scrape-it-core uses this field instead the `trim` that was in the documentation.